### PR TITLE
Performance improvements - allocs and times

### DIFF
--- a/src/HCubature.jl
+++ b/src/HCubature.jl
@@ -72,7 +72,6 @@ function hcubature_(f, a::SVector{n,T}, b::SVector{n,T}, norm, rtol_, atol,
     maxevals < 0 && throw(ArgumentError("invalid negative maxevals"))
     initdiv < 1 && throw(ArgumentError("initdiv must be positive"))
 
-
     I = fe.I
     E = fe.E
     kdiv = fe.kdiv

--- a/src/HCubature.jl
+++ b/src/HCubature.jl
@@ -45,10 +45,10 @@ function (::Trivial)(f, a::SVector{0}, b::SVector{0}, norm)
 end
 cubrule(::Val{0}, ::Type{T}) where {T} = Trivial()
 countevals(::Trivial) = 1
-struct FirstEval{TI, TE, TK, TΔ, TB, TR}
+struct FirstEval{TI, TE, TΔ, TB, TR}
   I::TI
   E::TE
-  kdiv::TK
+  kdiv::Int
   Δ::TΔ
   b1::TB
   rule::TR

--- a/src/HCubature.jl
+++ b/src/HCubature.jl
@@ -45,6 +45,7 @@ function (::Trivial)(f, a::SVector{0}, b::SVector{0}, norm)
 end
 cubrule(::Val{0}, ::Type{T}) where {T} = Trivial()
 countevals(::Trivial) = 1
+
 struct FirstEval{TI, TE, TΔ, TB, TR}
   I::TI
   E::TE


### PR DESCRIPTION
I was just investigating a performance problem with my code, which led me to investigate `HCubature.jl`. I made some small changes to pull out the first call, `FirstEval`, in front of `hcubature_` to make a function barrier, which I think has helped enable Julia to compile better code(?). Either way, it looks like it's improved the allocations and timings on my machine on `Version 1.8.3-pre.0`, but it's definitely worth confirming that this improvement is not anomalous.

This branch:

```julia
julia> using HCubature, BenchmarkTools
[ Info: Precompiling HCubature [19dc6840-f33b-545b-b366-655c7e3ffd49]

julia> @benchmark hcubature(x -> cos(x[1])*cos(x[2]), [0,0], [1,1])
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  26.951 μs …  3.035 ms  ┊ GC (min … max): 0.00% … 96.77%
 Time  (median):     27.893 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   30.028 μs ± 55.798 μs  ┊ GC (mean ± σ):  3.60% ±  1.93%

  ▆█▆▅▃▁                                                      ▂
  ████████▇▆▆▆▆▅▆▆▆▆▅▅▅▅▃▅▅▅▄▁▃▄▁▄▄▄▄▄▅▅▅▄▅▄▄▅▄▄▆▄▃▅▃▁▁▅▃▄▄▅▃ █
  27 μs        Histogram: log(frequency) by time      62.3 μs <

 Memory estimate: 19.33 KiB, allocs estimate: 580.
```

On master v1.5.0:

```julia
julia> using HCubature, BenchmarkTools

julia> @benchmark hcubature(x -> cos(x[1])*cos(x[2]), [0,0], [1,1])
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  47.759 μs …   4.363 ms  ┊ GC (min … max): 0.00% … 96.87%
 Time  (median):     49.287 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   54.187 μs ± 103.596 μs  ┊ GC (mean ± σ):  5.51% ±  2.87%

  ▆█▆▄▃▂                                                       ▁
  ████████▇▆▇▇▇▆▆▅▆▆▅▅▆▅▄▅▅▃▅▅▅▄▅▅▄▄▄▃▄▁▅▄▅▄▅▅▄▁▄▅▄▆▅▄▅▅▄▄▁▄▄▅ █
  47.8 μs       Histogram: log(frequency) by time       106 μs <

 Memory estimate: 41.25 KiB, allocs estimate: 1045.
```