### PR TITLE
Add integrand function type parameter

### DIFF
--- a/src/HCubature.jl
+++ b/src/HCubature.jl
@@ -46,7 +46,8 @@ end
 cubrule(::Val{0}, ::Type{T}) where {T} = Trivial()
 countevals(::Trivial) = 1
 
-function hcubature_(f, a::SVector{n,T}, b::SVector{n,T}, norm, rtol_, atol, maxevals, initdiv) where {n, T<:Real}
+function hcubature_(f::F, a::SVector{n,T}, b::SVector{n,T}, norm, rtol_, atol,
+                    maxevals, initdiv) where {F, n, T<:Real}
     rtol = rtol_ == 0 == atol ? sqrt(eps(T)) : rtol_
     (rtol < 0 || atol < 0) && throw(ArgumentError("invalid negative tolerance"))
     maxevals < 0 && throw(ArgumentError("invalid negative maxevals"))
@@ -121,11 +122,11 @@ function hcubature_(f, a::SVector{n,T}, b::SVector{n,T}, norm, rtol_, atol, maxe
     return I,E
 end
 
-function hcubature_(f, a::AbstractVector{T}, b::AbstractVector{S},
-                    norm, rtol, atol, maxevals, initdiv) where {T<:Real, S<:Real}
+function hcubature_(f::F, a::AbstractVector{T}, b::AbstractVector{S},
+                    norm, rtol, atol, maxevals, initdiv) where {F, T<:Real, S<:Real}
     length(a) == length(b) || throw(DimensionMismatch("endpoints $a and $b must have the same length"))
-    F = float(promote_type(T, S))
-    return hcubature_(f, SVector{length(a),F}(a), SVector{length(a),F}(b), norm, rtol, atol, maxevals, initdiv)
+    U = float(promote_type(T, S))
+    return hcubature_(f, SVector{length(a),U}(a), SVector{length(a),U}(b), norm, rtol, atol, maxevals, initdiv)
 end
 function hcubature_(f, a::Tuple{Vararg{Real,n}}, b::Tuple{Vararg{Real,n}}, norm, rtol, atol, maxevals, initdiv) where {n}
     hcubature_(f, SVector{n}(float.(a)), SVector{n}(float.(b)), norm, rtol, atol, maxevals, initdiv)
@@ -174,8 +175,8 @@ test above) is `norm`, but you can pass an alternative norm by
 the `norm` keyword argument.  (This is especially useful when `f`
 returns a vector of integrands with different scalings.)
 """
-hcubature(f, a, b; norm=norm, rtol::Real=0, atol::Real=0,
-                   maxevals::Integer=typemax(Int), initdiv::Integer=1) =
+hcubature(f::F, a, b; norm=norm, rtol::Real=0, atol::Real=0,
+                   maxevals::Integer=typemax(Int), initdiv::Integer=1) where F =
     hcubature_(f, a, b, norm, rtol, atol, maxevals, initdiv)
 
 """
@@ -193,10 +194,11 @@ Alternatively, for 1d integrals you can import the [`QuadGK`](@ref) module
 and call the [`quadgk`](@ref) function, which provides additional flexibility
 e.g. in choosing the order of the quadrature rule.
 """
-function hquadrature(f, a::T, b::S; norm=norm, rtol::Real=0, atol::Real=0,
-                     maxevals::Integer=typemax(Int), initdiv::Integer=1) where {T<:Real, S<:Real}
-    F = float(promote_type(T, S))
-    hcubature_(x -> f(x[1]), SVector{1,F}(a), SVector{1,F}(b), norm, rtol, atol, maxevals, initdiv)
+function hquadrature(f::F, a::T, b::S; norm=norm, rtol::Real=0, atol::Real=0,
+                     maxevals::Integer=typemax(Int), initdiv::Integer=1) where
+  {F, T<:Real, S<:Real}
+    U = float(promote_type(T, S))
+    hcubature_(x -> f(x[1]), SVector{1,U}(a), SVector{1,U}(b), norm, rtol, atol, maxevals, initdiv)
 end
 
 end # module

--- a/src/HCubature.jl
+++ b/src/HCubature.jl
@@ -176,7 +176,7 @@ the `norm` keyword argument.  (This is especially useful when `f`
 returns a vector of integrands with different scalings.)
 """
 hcubature(f::F, a, b; norm=norm, rtol::Real=0, atol::Real=0,
-                   maxevals::Integer=typemax(Int), initdiv::Integer=1) where F =
+          maxevals::Integer=typemax(Int), initdiv::Integer=1) where F =
     hcubature_(f, a, b, norm, rtol, atol, maxevals, initdiv)
 
 """
@@ -196,7 +196,7 @@ e.g. in choosing the order of the quadrature rule.
 """
 function hquadrature(f::F, a::T, b::S; norm=norm, rtol::Real=0, atol::Real=0,
                      maxevals::Integer=typemax(Int), initdiv::Integer=1) where
-  {F, T<:Real, S<:Real}
+                     {F, T<:Real, S<:Real}
     U = float(promote_type(T, S))
     hcubature_(x -> f(x[1]), SVector{1,U}(a), SVector{1,U}(b), norm, rtol, atol, maxevals, initdiv)
 end

--- a/src/gauss-kronrod.jl
+++ b/src/gauss-kronrod.jl
@@ -23,7 +23,7 @@ GaussKronrod(::Type{Float64}) = gk_float64
 
 countevals(g::GaussKronrod) = 17
 
-function (g::GaussKronrod{T})(f, a_::SVector{1}, b_::SVector{1}, norm=norm) where {T}
+function (g::GaussKronrod{T})(f::F, a_::SVector{1}, b_::SVector{1}, norm=norm) where {F, T}
     a = a_[1]
     b = b_[1]
     c = (a+b)*T(0.5)

--- a/src/genz-malik.jl
+++ b/src/genz-malik.jl
@@ -113,7 +113,7 @@ for an integrand `f`.  Returns the estimated integral `I`, the estimated
 error `E` (via the given `norm`), and the suggested coordinate `k` ∈ `1:n`
 to subdivide next.
 """
-function (g::GenzMalik{n,T})(f, a::SVector{n}, b::SVector{n}, norm=norm) where {n,T}
+function (g::GenzMalik{n,T})(f::F, a::SVector{n}, b::SVector{n}, norm=norm) where {F, n,T}
     c = T(0.5).*(a.+b)
     Δ = T(0.5).*abs.(b.-a)
     V = prod(Δ)


### PR DESCRIPTION
Related to and supplants #44, this makes the change `hcubature(f, a, b ...` to `hcubature(f::F, a, b... where F`. The same benchmark as the other PR on the same machine is

```julia
julia> using HCubature, BenchmarkTools

julia> @benchmark hcubature(x -> cos(x[1])*cos(x[2]), [0,0], [1,1])
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  11.121 μs …  8.734 ms  ┊ GC (min … max): 0.00% … 99.38%
 Time  (median):     11.484 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   12.554 μs ± 87.231 μs  ┊ GC (mean ± σ):  6.91% ±  0.99%

     ▄▇▆▆██▆▃▁                                                 
  ▁▄▇█████████▇▆▅▄▄▃▃▃▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁ ▃
  11.1 μs         Histogram: frequency by time        13.6 μs <

 Memory estimate: 4.12 KiB, allocs estimate: 27.
```