### PR TITLE
correct countevals for GaussKronrod

### DIFF
--- a/src/gauss-kronrod.jl
+++ b/src/gauss-kronrod.jl
@@ -21,7 +21,7 @@ end
 const gk_float64 = GaussKronrod{Float64}(QuadGK.kronrod(Float64,7)...)
 GaussKronrod(::Type{Float64}) = gk_float64
 
-countevals(g::GaussKronrod) = 17
+countevals(g::GaussKronrod) = 15
 
 function (g::GaussKronrod{T})(f, a_::SVector{1}, b_::SVector{1}, norm=norm) where {T}
     a = a_[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,14 +37,23 @@ end
 
 @testset "countevals" begin
       let g = HCubature.GaussKronrod(Float64)
-            @test HCubature.countevals(g) == 1 + 2length(g.w)
+            @test HCubature.countevals(g) == 2length(g.w) - 1
+            gcnt[] = 0
+            hquadrature(cnt(one), 0, 1)
+            @test HCubature.countevals(g) == gcnt[]
       end
       for n = 2:10
             let g = HCubature.GenzMalik(Val{n}(), Float64)
                   @test HCubature.countevals(g) == 1 + 4length(g.p[1]) + length(g.p[3]) + length(g.p[4])
+                  gcnt[] = 0
+                  hcubature(cnt(x -> 1.0), ntuple(zero, Val{n}()), ntuple(one, Val{n}()))
+                  @test HCubature.countevals(g) == gcnt[]
             end
       end
       @test HCubature.countevals(HCubature.Trivial()) == 1
+      gcnt[] = 0
+      hcubature(cnt(x -> 1.0), SVector{0,Float64}(), SVector{0,Float64}())
+      @test HCubature.countevals(HCubature.Trivial()) == gcnt[]
 end
 
 @testset "axischoosing" begin


### PR DESCRIPTION
It looked like countevals for GaussKronrod was overcounting because length(g.x) = 1 + order. I also added tests for the remaining rules for a trivial integrand to double check their counts are correct.