### PR TITLE
use SizedArray for non-isbits types

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
 #          - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-julia = "1"
+julia = "1.6"
 Combinatorics = "1.0"
 DataStructures = "0.15, 0.16, 0.17, 0.18"
 QuadGK = "2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HCubature"
 uuid = "19dc6840-f33b-545b-b366-655c7e3ffd49"
-version = "1.5.2"
+version = "1.6.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ julia = "1"
 Combinatorics = "1.0"
 DataStructures = "0.15, 0.16, 0.17, 0.18"
 QuadGK = "2"
-StaticArrays = "0.8, 0.9, 0.10, 0.11, 0.12, 1"
+StaticArrays = "1.6.4"
 LinearAlgebra = "<0.0.1, 1"
 Test = "<0.0.1, 1"
 

--- a/src/HCubature.jl
+++ b/src/HCubature.jl
@@ -114,8 +114,8 @@ function hcubature_(f::F, a::SVector{n,T}, b::SVector{n,T}, norm, rtol_, atol, m
 
     push!(boxes, firstbox)
 
-    ma = MVector(a)
-    mb = MVector(b)
+    ma = Base.copymutable(a)
+    mb = Base.copymutable(b)
 
     if initdiv > 1 # initial box divided by initdiv along each dimension
         skip = true # skip the first box, which we already added

--- a/src/genz-malik.jl
+++ b/src/genz-malik.jl
@@ -12,7 +12,7 @@ with k components equal to λ and other components equal to zero.
 function combos(k::Integer, λ::T, ::Val{n}) where {n, T<:Number}
     combos = Combinatorics.combinations(1:n, k)
     p = Vector{SVector{n,T}}(undef, length(combos))
-    v = MVector{n,T}(undef)
+    v = similar(SVector{n,T})
     for (i,c) in enumerate(combos)
         v .= 0
         v[c] .= λ
@@ -32,7 +32,7 @@ function signcombos(k::Integer, λ::T, ::Val{n}) where {n, T<:Number}
     combos = Combinatorics.combinations(1:n, k)
     twoᵏ = 1 << k
     p = Vector{SVector{n,T}}(undef, length(combos) * twoᵏ)
-    v = MVector{n,T}(undef)
+    v = similar(SVector{n,T})
     for (i,c) in enumerate(combos)
         j = (i-1)*twoᵏ + 1
         v .= 0
@@ -124,7 +124,7 @@ function (g::GenzMalik{n,T})(f::F, a::SVector{n}, b::SVector{n}, norm=norm) wher
     f₃ = zero(f₁)
     twelvef₁ = 12f₁
     maxdivdiff = zero(norm(f₁))
-    divdiff = MVector{n,typeof(maxdivdiff)}(undef)
+    divdiff = similar(SVector{n,typeof(maxdivdiff)})
     for i = 1:n
         p₂ = Δ .* g.p[1][i]
         f₂ᵢ = f(c + p₂) + f(c - p₂)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,3 +104,9 @@ end
     @test hquadrature(x -> 1.0, 1, -1)[1] ≈ -2
     @test hcubature(x -> 1.0, [-1,1], [1,-1])[1] ≈ -4
 end
+
+@testset "issue 60" begin
+    T = BigFloat
+    @test hquadrature(x -> exp(-x^2), T(0), T(1); rtol = 1e-20)[1] ≈ 0.7468241328124270254
+    @test hcubature(x -> exp(-x[1]^2), T.((0,0)), T.((1,1)); rtol = 1e-20)[1] ≈ 0.7468241328124270254
+end


### PR DESCRIPTION
Fixes #60 

I've also updated the compat to demand `StaticArrays` to be at least `1.6.4`, and added a couple of tests.

As expected, the benchmarks were indistinguishable. I've timed with the following code, copied from `runtests.jl`:

```julia
    @benchmark hcubature(x -> cos(x[1]), (0,), (1,))
    @benchmark hcubature(x -> cos(x[1])*cos(x[2]), [0,0], [1,1])
    f(x) = sin(x[1] + 3*sin(2*x[2] + 4*sin(3*x[3])))
    @benchmark hcubature(f, (0,0,0),(3,3,3), rtol=1e-6)
```

Got 89.942 ns, 5.648 μs, and 67.489 ms in the old version, and 85.637 ns, 5.662 μs, and 66.269 ms in the new version.