### PR TITLE
Implement `hcubature_count` and `hcubature_print`

### DIFF
--- a/src/HCubature.jl
+++ b/src/HCubature.jl
@@ -250,12 +250,12 @@ it may be possible to mathematically transform the problem in some way
 to improve the convergence rate.
 """
 function hcubature_count(f, a, b; kws...)
-    count = 0
-    i = hcubature(a, b; kws...) do x
-        count += 1
+    count = Ref(0)
+    I, E = hcubature(a, b; kws...) do x
+        count[] += 1
         f(x)
     end
-    return (i..., count)
+    return (I, E, count[])
 end
 
 """

--- a/src/HCubature.jl
+++ b/src/HCubature.jl
@@ -237,6 +237,51 @@ hcubature(f, a, b; norm=norm, rtol::Real=0, atol::Real=0,
 
 
 """
+    hcubature_count(f, a, b; kws...)
+
+Identical to [`hcubature`](@ref) but returns a triple `(I, E, count)`
+of the estimated integral `I`, the estimated error bound `E`, and a `count`
+of the number of times the integrand `f` was evaluated.
+
+The count of integrand evaluations is a useful performance metric: a large
+number typically indicates a badly behaved integrand (with singularities,
+discontinuities, sharp peaks, and/or rapid oscillations), in which case
+it may be possible to mathematically transform the problem in some way
+to improve the convergence rate.
+"""
+function hcubature_count(f, a, b; kws...)
+    count = 0
+    i = hcubature(a, b; kws...) do x
+        count += 1
+        f(x)
+    end
+    return (i..., count)
+end
+
+"""
+    hcubature_print([io], f, a, b; kws...)
+
+Identical to [`hcubature`](@ref), but **prints** each integrand
+evaluation to the stream `io` (defaults to `stdout`) in the form:
+```
+f(x1) = y1
+f(x2) = y2
+...
+```
+which is useful for pedagogy and debugging.
+
+Also, like [`hcubature_count`](@ref), it returns a triple `(I, E, count)`
+of the estimated integral `I`, the estimated error bound `E`, and a `count`
+of the number of times the integrand `f` was evaluated.
+"""
+hcubature_print(io::IO, f, a, b; kws...) = hcubature_count(a, b; kws...) do x
+    y = f(x)
+    println(io, "f($x) = $y")
+    y
+end
+hcubature_print(f, a, b; kws...) = hcubature_print(stdout, f, a, b; kws...)
+
+"""
     hquadrature(f, a, b; norm=norm, rtol=sqrt(eps), atol=0, maxevals=typemax(Int), initdiv=1)
 
 Compute the integral of f(x) from `a` to `b`.  The

--- a/src/HCubature.jl
+++ b/src/HCubature.jl
@@ -20,7 +20,7 @@ module HCubature
 using StaticArrays, LinearAlgebra
 import Combinatorics, DataStructures, QuadGK
 
-export hcubature, hquadrature, hcubature_buffer
+export hcubature, hquadrature, hcubature_buffer, hcubature_count, hcubature_print
 
 include("genz-malik.jl")
 include("gauss-kronrod.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,12 @@ using Test
       for d in 1:5
             @test hcubature(x -> 1, fill(0,d), fill(1,d))[1] ≈ 1 rtol=1e-13
       end
-      @test hcubature_count(x -> 2, (0,0), (2pi, pi))[1] ≈ 4pi^2
+end
+
+@testset "count" begin
+      (i, e, count) = hcubature_count(x -> 2, (0,0), (2pi, pi))[1]
+      @test i ≈ 4pi^2
+      @test count == HCubature.countevals(HCubature.GenzMalik(Val(2)))
 end
 
 @testset "print" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,13 +24,18 @@ end
 end
 
 @testset "print" begin
+      # Capture println's in a buffer, ensure one printed line per integrand eval
       let io = IOBuffer()
-            # Capture println's in a buffer, ensure one line per integrand function eval
             (i, e, count) = hcubature_print(io, x -> 2, (0,0), (2pi, pi))
             regex = r"f\((?<x>.+?)\) = (?<y>.+?)"
             io_lines = collect(eachmatch(regex, String(take!(io))))
+            @test i ≈ 4pi^2
             @test length(io_lines) == count
       end
+
+      # Test wrapper without io specified
+      (i, e, count) = hcubature_print(x -> 2, (0,0), (2pi, pi));
+      @test i ≈ 4pi^2
 end
 
 # function wrapper for counting evaluations

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ using Test
 end
 
 @testset "count" begin
-      (i, e, count) = hcubature_count(x -> 2, (0,0), (2pi, pi))[1]
+      (i, e, count) = hcubature_count(x -> 2, (0,0), (2pi, pi))
       @test i ≈ 4pi^2
       @test count == HCubature.countevals(HCubature.GenzMalik(Val(2)))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ using Test
       for d in 1:5
             @test hcubature(x -> 1, fill(0,d), fill(1,d))[1] ≈ 1 rtol=1e-13
       end
-      @test @inferred(hcubature_count(x -> 2, (0,0), (2pi, pi))[1]) ≈ 4pi^2
+      @test hcubature_count(x -> 2, (0,0), (2pi, pi))[1] ≈ 4pi^2
 end
 
 @testset "print" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,7 @@ end
       f() = hcubature_print(x -> 2, (0,0), (2pi, pi))
       (i, e, count) = redirect_stdout(f, devnull);
       @test i ≈ 4pi^2
+      @test count == HCubature.countevals(HCubature.GenzMalik(Val(2)))
 end
 
 # function wrapper for counting evaluations

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,8 +33,10 @@ end
             @test length(io_lines) == count
       end
 
-      # Test wrapper without io specified
-      (i, e, count) = hcubature_print(x -> 2, (0,0), (2pi, pi));
+      # Test hcubature_print(f, a, b) without io arg specified
+      # Suppress output of internal printing to stdout
+      f() = hcubature_print(x -> 2, (0,0), (2pi, pi))
+      (i, e, count) = redirect_stdout(f, devnull);
       @test i ≈ 4pi^2
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,17 @@ using Test
       for d in 1:5
             @test hcubature(x -> 1, fill(0,d), fill(1,d))[1] ≈ 1 rtol=1e-13
       end
+      @test @inferred(hcubature_count(x -> 2, (0,0), (2pi, pi))[1]) ≈ 4pi^2
+end
+
+@testset "print" begin
+      let io = IOBuffer()
+            # Capture println's in a buffer, ensure one line per integrand function eval
+            (i, e, count) = hcubature_print(io, x -> 2, (0,0), (2pi, pi))
+            regex = r"y\((?<x>.+?)\) = (?<y>.+?)"
+            io_lines = collect(eachmatch(regex, String(take!(io))))
+            @test length(io_lines) == count
+      end
 end
 
 # function wrapper for counting evaluations

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,7 @@ end
       let io = IOBuffer()
             # Capture println's in a buffer, ensure one line per integrand function eval
             (i, e, count) = hcubature_print(io, x -> 2, (0,0), (2pi, pi))
-            regex = r"y\((?<x>.+?)\) = (?<y>.+?)"
+            regex = r"f\((?<x>.+?)\) = (?<y>.+?)"
             io_lines = collect(eachmatch(regex, String(take!(io))))
             @test length(io_lines) == count
       end


### PR DESCRIPTION
## Changes
- Implements an `hcubature_count` function, as suggested by #68, which counts the number of integrand function evaluations and returns `(I, E, count)`.
- Implements an `hcubature_print` function, shamelessly adapted from `QuadGK.quadgk_print` (credit to @stevengj), which prints a line `f($x) = $(f(x))` for every integrand function evaluation and returns `(I, E, count)`.